### PR TITLE
Remove unused dependency on gridcss component.

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,5 +1,3 @@
-@import '@economist/component-gridcss';
-
 .NotFoundHandler {
   width: 100%;
   max-width: 1220px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-404",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A basic 404 page",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
-    "@economist/component-gridcss": "^2.0.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   },


### PR DESCRIPTION
I've thoroughly checked, and it's certainly not used!

This is currently the only component that requires gridcss in the revamp, which is not so cool because it represents a bit of unused CSS.